### PR TITLE
Use relative links in the nav

### DIFF
--- a/components/nav/nav.hbs
+++ b/components/nav/nav.hbs
@@ -8,7 +8,7 @@
     {{#each schemas}}
       <li>
         <p>
-          <a href='{{#if ../home}}schemas/{{filename}}{{else}}{{filename}}{{/if}}'>
+          <a href='{{#if ../home}}schemas/{{filename}}{{else}}./{{filename}}{{/if}}'>
             {{#if schema.title}}
               {{md schema.title 'inline'}}
             {{else}}


### PR DESCRIPTION
If relative hrefs are not used, the links don't work after clicking into a schema. 

Tested this locally